### PR TITLE
fix ImportError due to version difference

### DIFF
--- a/distkeras/workers.py
+++ b/distkeras/workers.py
@@ -24,7 +24,14 @@ import numpy as np
 
 import threading
 
-import queue
+import sys
+
+# "queue" module in python 3 is named "Queue" in python 2
+use_python3 = sys.version_info[0] == 3
+if use_python3:
+    import queue
+else:
+    import Queue as queue
 
 import random
 


### PR DESCRIPTION
"import queue" works in python 3 but causes ImportError in python 2.x since the right name should be "Queue". Added a switch to make it compatible with python 2.