### PR TITLE
Set hostname and port through environment variable

### DIFF
--- a/distkeras/networking.py
+++ b/distkeras/networking.py
@@ -3,17 +3,26 @@
 ## BEGIN Imports. ##############################################################
 
 import pickle
-
+import os
 import socket
 
 ## END Imports. ################################################################
 
 def determine_host_address():
-    """Determines the human-readable host address of the local machine."""
-    host_address = socket.gethostbyname(socket.gethostname())
-
+    """Determines the human-readable host address of the local machine. 
+    First checks if environment variable DISTKERAS_HOSTNAME is set, and 
+    if so uses this as host name. Otherwise, checks using socket"""
+    host_env_var = 'DISTKERAS_HOSTNAME'
+    host_address = os.environ.get(host_env_var, socket.gethostbyname(socket.gethostname()))
     return host_address
 
+def determine_port():
+    """Determines port to connect to on local machine. 
+    First checks if environment variable DISTKERAS_PORT is set, and 
+    if so uses this as port. Otherwise, assign to a default"""
+    port_env_var = 'DISTKERAS_PORT'
+    port = int(os.environ.get(port_env_var, 5000))
+    return port
 
 def recvall(connection, num_bytes):
     """Reads `num_bytes` bytes from the specified connection.


### PR DESCRIPTION
Hi,

This is a small change where `master_host` and `master_port` are read from optional environment variables (if they are not present behavior stays the same). In our use case we need to specify both the host and port because we are running dist-keras on Docker. I thought it would be useful for others who are using Docker or in the case where the Spark master is running in a container. For us using environment variables rather than passing these in as parameters makes more sense because we don't want everyone using this package in our system to have to worry about this. Hope this is helpful.