### PR TITLE
Addressing AnalysisException error in workflow example

### DIFF
--- a/examples/workflow.ipynb
+++ b/examples/workflow.ipynb
@@ -465,13 +465,13 @@
     "# 2. Output dimensionality: 5\n",
     "# With these parameters, we obtain the following vector in the DataFrame column: [0,0,0,1,0]\n",
     "\n",
-    "transformer = OneHotTransformer(output_dim=nb_classes, input_col=\"label_index\", output_col=\"label\")\n",
+    "transformer = OneHotTransformer(output_dim=nb_classes, input_col=\"label_index\", output_col=\"label_out\")\n",
     "dataset = transformer.transform(dataset)\n",
     "# Only select the columns we need (less data shuffling) while training.\n",
-    "dataset = dataset.select(\"features_normalized\", \"label_index\", \"label\")\n",
+    "dataset = dataset.select(\"features_normalized\", \"label_index\", \"label_out\")\n",
     "\n",
     "# Show the expected output vectors of the neural network.\n",
-    "dataset.select(\"label_index\", \"label\").take(1)"
+    "dataset.select(\"label_index\", \"label_out\").take(1)"
    ]
   },
   {
@@ -597,7 +597,7 @@
     "    # Allocate a Distributed Keras Accuracy evaluator.\n",
     "    evaluator = AccuracyEvaluator(prediction_col=\"prediction_index\", label_col=\"label_index\")\n",
     "    # Clear the prediction column from the testset.\n",
-    "    test_set = test_set.select(\"features_normalized\", \"label_index\", \"label\")\n",
+    "    test_set = test_set.select(\"features_normalized\", \"label_index\", \"label_out\")\n",
     "    # Apply a prediction from a trained model.\n",
     "    predictor = ModelPredictor(keras_model=trained_model, features_col=\"features_normalized\")\n",
     "    test_set = predictor.predict(test_set)\n",
@@ -674,7 +674,7 @@
    "source": [
     "trainer = SingleTrainer(keras_model=model, worker_optimizer=optimizer,\n",
     "                        loss=loss, features_col=\"features_normalized\",\n",
-    "                        label_col=\"label\", num_epoch=1, batch_size=32)\n",
+    "                        label_col=\"label_out\", num_epoch=1, batch_size=32)\n",
     "trained_model = trainer.train(training_set)"
    ]
   },
@@ -718,7 +718,7 @@
    "outputs": [],
    "source": [
     "trainer = AEASGD(keras_model=model, worker_optimizer=optimizer, loss=loss, num_workers=num_workers, \n",
-    "                 batch_size=32, features_col=\"features_normalized\", label_col=\"label\", num_epoch=1,\n",
+    "                 batch_size=32, features_col=\"features_normalized\", label_col=\"label_out\", num_epoch=1,\n",
     "                 communication_window=32, rho=5.0, learning_rate=0.1)\n",
     "trainer.set_parallelism_factor(1)\n",
     "trained_model = trainer.train(training_set)"
@@ -762,7 +762,7 @@
    "outputs": [],
    "source": [
     "trainer = EAMSGD(keras_model=model, worker_optimizer=optimizer, loss=loss, num_workers=num_workers,\n",
-    "                 batch_size=32, features_col=\"features_normalized\", label_col=\"label\", num_epoch=1,\n",
+    "                 batch_size=32, features_col=\"features_normalized\", label_col=\"label_out\", num_epoch=1,\n",
     "                 communication_window=32, rho=5.0, learning_rate=0.1, momentum=0.6)\n",
     "trainer.set_parallelism_factor(1)\n",
     "trained_model = trainer.train(training_set)"
@@ -800,7 +800,7 @@
    "source": [
     "trainer = DOWNPOUR(keras_model=model, worker_optimizer=optimizer, loss=loss, num_workers=num_workers,\n",
     "                   batch_size=32, communication_window=5, learning_rate=0.05, num_epoch=1,\n",
-    "                   features_col=\"features_normalized\", label_col=\"label\")\n",
+    "                   features_col=\"features_normalized\", label_col=\"label_out\")\n",
     "trainer.set_parallelism_factor(1)\n",
     "trained_model = trainer.train(training_set)"
    ]


### PR DESCRIPTION
Without this change, currently getting the error 
```python
---------------------------------------------------------------------------
AnalysisException                         Traceback (most recent call last)
<ipython-input-38-3d60eef83573> in <module>()
      1 # Only select the columns we need (less data shuffling) while training.
----> 2 dataset = dataset.select("features_normalized", "label_index", "label")
      3 print(dataset)

/opt/mapr/spark/spark-2.1.0/python/pyspark/sql/dataframe.py in select(self, *cols)
    990         [Row(name=u'Alice', age=12), Row(name=u'Bob', age=15)]
    991         """
--> 992         jdf = self._jdf.select(self._jcols(*cols))
    993         return DataFrame(jdf, self.sql_ctx)
    994 

/opt/mapr/spark/spark-2.1.0/python/lib/py4j-0.10.4-src.zip/py4j/java_gateway.py in __call__(self, *args)
   1131         answer = self.gateway_client.send_command(command)
   1132         return_value = get_return_value(
-> 1133             answer, self.gateway_client, self.target_id, self.name)
   1134 
   1135         for temp_arg in temp_args:

/opt/mapr/spark/spark-2.1.0/python/pyspark/sql/utils.py in deco(*a, **kw)
     67                                              e.java_exception.getStackTrace()))
     68             if s.startswith('org.apache.spark.sql.AnalysisException: '):
---> 69                 raise AnalysisException(s.split(': ', 1)[1], stackTrace)
     70             if s.startswith('org.apache.spark.sql.catalyst.analysis'):
     71                 raise AnalysisException(s.split(': ', 1)[1], stackTrace)

AnalysisException: u"Reference 'label_out' is ambiguous, could be: label#320, label#324.;"
```
when running the section

```python
# For example:
# 1. Assume we have a label index: 3
# 2. Output dimensionality: 5
# With these parameters, we obtain the following vector in the DataFrame column: [0,0,0,1,0]

transformer = OneHotTransformer(output_dim=nb_classes, input_col="label_index", output_col="label")
dataset = transformer.transform(dataset)
# Only select the columns we need (less data shuffling) while training.
dataset = dataset.select("features_normalized", "label_index", "label")
```
Seems to be due to the fact that he `raw_dataset` already contains a field called `Label` and there seems to be a conflict in differentiating between this field and the `label` field that gets created later (as if the pyspark.sql SparkSession looks at both in lowercase form).